### PR TITLE
Significantly changed packaging layout to be more categorical

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,13 +6,13 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:name="edu.purdue.app.PurdueApplication"
+        android:name=".application.PurdueApplication"
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.Purdue" >
         <activity
-            android:name="edu.purdue.app.main.MainMenuActivity"
+            android:name=".activity.MainMenuActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait">
             <intent-filter>
@@ -22,9 +22,9 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="edu.purdue.app.WebViewActivity"
+            android:name=".activity.WebViewActivity"
             android:label="@string/title_activity_web_view"
-            android:parentActivityName="edu.purdue.app.main.MainMenuActivity" >
+            android:parentActivityName=".activity.MainMenuActivity" >
 
             <!-- The meta-data element is needed for versions lower than 4.1 -->
             <meta-data
@@ -37,9 +37,9 @@
             android:value="@integer/google_play_services_version" />
 
         <activity
-            android:name=".prefs.SettingsActivity"
+            android:name=".activity.SettingsActivity"
             android:label="@string/title_activity_settings"
-            android:parentActivityName="edu.purdue.app.main.MainMenuActivity" >
+            android:parentActivityName=".activity.MainMenuActivity" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="edu.purdue.app.main.MainMenuActivity" />

--- a/app/src/main/java/edu/purdue/app/activity/MainMenuActivity.java
+++ b/app/src/main/java/edu/purdue/app/activity/MainMenuActivity.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.main;
+package edu.purdue.app.activity;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -22,10 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.purdue.app.R;
-import edu.purdue.app.WebViewActivity;
-import edu.purdue.app.main.MainMenuItem;
-import edu.purdue.app.prefs.SettingsActivity;
-import edu.purdue.app.tracking.TrackingUtils;
+import edu.purdue.app.adapter.CustomGridAdapter;
+import edu.purdue.app.model.MainMenuItem;
+import edu.purdue.app.utility.TrackingUtils;
 import edu.purdue.app.utility.Connectivity;
 
 import static android.widget.AdapterView.OnItemClickListener;

--- a/app/src/main/java/edu/purdue/app/activity/SettingsActivity.java
+++ b/app/src/main/java/edu/purdue/app/activity/SettingsActivity.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.prefs;
+package edu.purdue.app.activity;
 
 import android.annotation.TargetApi;
 import android.content.Context;
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import edu.purdue.app.R;
-import edu.purdue.app.tracking.TrackingUtils;
+import edu.purdue.app.utility.TrackingUtils;
 
 /**
  * A {@link PreferenceActivity} that presents a set of application settings. On
@@ -41,8 +41,8 @@ public class SettingsActivity extends PreferenceActivity {
      * shown on tablets.
      */
     private static final boolean ALWAYS_SIMPLE_PREFS = true;
-    private static final String[] validFragments = new String[]{"edu.purdue.app.prefs.DataSyncPreferenceFragment",
-            "edu.purdue.app.prefs.GeneralPreferenceFragment" };
+    private static final String[] validFragments = new String[]{"edu.purdue.app.fragment.DataSyncPreferenceFragment",
+            "edu.purdue.app.fragment.GeneralPreferenceFragment" };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -220,7 +220,7 @@ public class SettingsActivity extends PreferenceActivity {
      *
      * @see #sBindPreferenceSummaryToValueListener
      */
-    protected static void bindPreferenceSummaryToValue(Preference preference) {
+    public static void bindPreferenceSummaryToValue(Preference preference) {
         // Set the listener to watch for value changes.
         preference.setOnPreferenceChangeListener(sBindPreferenceSummaryToValueListener);
 

--- a/app/src/main/java/edu/purdue/app/activity/WebViewActivity.java
+++ b/app/src/main/java/edu/purdue/app/activity/WebViewActivity.java
@@ -1,8 +1,7 @@
-package edu.purdue.app;
+package edu.purdue.app.activity;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
@@ -12,10 +11,8 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import com.google.android.gms.analytics.HitBuilders;
-import com.google.android.gms.analytics.Tracker;
-
-import edu.purdue.app.tracking.TrackingUtils;
+import edu.purdue.app.R;
+import edu.purdue.app.utility.TrackingUtils;
 
 
 public class WebViewActivity extends Activity {

--- a/app/src/main/java/edu/purdue/app/adapter/CustomGridAdapter.java
+++ b/app/src/main/java/edu/purdue/app/adapter/CustomGridAdapter.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.main;
+package edu.purdue.app.adapter;
 
 import android.content.Context;
 import android.view.LayoutInflater;
@@ -12,6 +12,7 @@ import org.askerov.dynamicgid.BaseDynamicGridAdapter;
 import java.util.List;
 
 import edu.purdue.app.R;
+import edu.purdue.app.model.CustomMenuItem;
 
 /**
  * Created by david on 5/14/14 for Purdue

--- a/app/src/main/java/edu/purdue/app/application/PurdueApplication.java
+++ b/app/src/main/java/edu/purdue/app/application/PurdueApplication.java
@@ -1,4 +1,4 @@
-package edu.purdue.app;
+package edu.purdue.app.application;
 
 import android.app.Application;
 import android.content.SharedPreferences;
@@ -11,7 +11,9 @@ import com.google.android.gms.analytics.Tracker;
 
 import java.util.HashMap;
 
-import edu.purdue.app.prefs.CustomOnSharedPreferenceChangeListener;
+import edu.purdue.app.BuildConfig;
+import edu.purdue.app.R;
+import edu.purdue.app.listener.CustomOnSharedPreferenceChangeListener;
 
 /**
  * Created by david on 5/19/14 for Purdue

--- a/app/src/main/java/edu/purdue/app/constants/PrefConstants.java
+++ b/app/src/main/java/edu/purdue/app/constants/PrefConstants.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.prefs;
+package edu.purdue.app.constants;
 
 /**
  * Created by david on 5/21/14 for Purdue

--- a/app/src/main/java/edu/purdue/app/fragment/DataSyncPreferenceFragment.java
+++ b/app/src/main/java/edu/purdue/app/fragment/DataSyncPreferenceFragment.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.prefs;
+package edu.purdue.app.fragment;
 
 import android.annotation.TargetApi;
 import android.os.Build;
@@ -6,23 +6,23 @@ import android.os.Bundle;
 import android.preference.PreferenceFragment;
 
 import edu.purdue.app.R;
+import edu.purdue.app.activity.SettingsActivity;
 
 /**
- * This fragment shows general preferences only. It is used when the
+ * This fragment shows data and sync preferences only. It is used when the
  * activity is showing a two-pane settings UI.
  */
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-public class GeneralPreferenceFragment extends PreferenceFragment {
+public class DataSyncPreferenceFragment extends PreferenceFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.pref_general);
+        addPreferencesFromResource(R.xml.pref_data_sync);
 
         // Bind the summaries of EditText/List/Dialog/Ringtone preferences
         // to their values. When their values change, their summaries are
         // updated to reflect the new value, per the Android Design
         // guidelines.
-        SettingsActivity.bindPreferenceSummaryToValue(findPreference("example_text"));
-        SettingsActivity.bindPreferenceSummaryToValue(findPreference("example_list"));
+        SettingsActivity.bindPreferenceSummaryToValue(findPreference("sync_frequency"));
     }
 }

--- a/app/src/main/java/edu/purdue/app/fragment/GeneralPreferenceFragment.java
+++ b/app/src/main/java/edu/purdue/app/fragment/GeneralPreferenceFragment.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.prefs;
+package edu.purdue.app.fragment;
 
 import android.annotation.TargetApi;
 import android.os.Build;
@@ -6,22 +6,24 @@ import android.os.Bundle;
 import android.preference.PreferenceFragment;
 
 import edu.purdue.app.R;
+import edu.purdue.app.activity.SettingsActivity;
 
 /**
- * This fragment shows data and sync preferences only. It is used when the
+ * This fragment shows general preferences only. It is used when the
  * activity is showing a two-pane settings UI.
  */
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-public class DataSyncPreferenceFragment extends PreferenceFragment {
+public class GeneralPreferenceFragment extends PreferenceFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.pref_data_sync);
+        addPreferencesFromResource(R.xml.pref_general);
 
         // Bind the summaries of EditText/List/Dialog/Ringtone preferences
         // to their values. When their values change, their summaries are
         // updated to reflect the new value, per the Android Design
         // guidelines.
-        SettingsActivity.bindPreferenceSummaryToValue(findPreference("sync_frequency"));
+        SettingsActivity.bindPreferenceSummaryToValue(findPreference("example_text"));
+        SettingsActivity.bindPreferenceSummaryToValue(findPreference("example_list"));
     }
 }

--- a/app/src/main/java/edu/purdue/app/listener/CustomOnSharedPreferenceChangeListener.java
+++ b/app/src/main/java/edu/purdue/app/listener/CustomOnSharedPreferenceChangeListener.java
@@ -1,9 +1,11 @@
-package edu.purdue.app.prefs;
+package edu.purdue.app.listener;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.google.android.gms.analytics.GoogleAnalytics;
+
+import edu.purdue.app.constants.PrefConstants;
 
 /**
  * Created by david on 5/21/14 for Purdue

--- a/app/src/main/java/edu/purdue/app/model/CustomMenuItem.java
+++ b/app/src/main/java/edu/purdue/app/model/CustomMenuItem.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.main;
+package edu.purdue.app.model;
 
 import android.graphics.drawable.Drawable;
 

--- a/app/src/main/java/edu/purdue/app/model/MainMenuItem.java
+++ b/app/src/main/java/edu/purdue/app/model/MainMenuItem.java
@@ -1,4 +1,4 @@
-package edu.purdue.app.main;
+package edu.purdue.app.model;
 
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;

--- a/app/src/main/java/edu/purdue/app/utility/TrackingUtils.java
+++ b/app/src/main/java/edu/purdue/app/utility/TrackingUtils.java
@@ -1,13 +1,11 @@
-package edu.purdue.app.tracking;
+package edu.purdue.app.utility;
 
 import android.app.Activity;
-import android.content.Context;
-import android.util.Log;
 
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Tracker;
 
-import edu.purdue.app.PurdueApplication;
+import edu.purdue.app.application.PurdueApplication;
 
 /**
  * Created by david on 5/21/14 for Purdue

--- a/app/src/main/res/layout/activity_web_view.xml
+++ b/app/src/main/res/layout/activity_web_view.xml
@@ -2,7 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="edu.purdue.app.WebViewActivity">
+    tools:context="edu.purdue.app.activity.WebViewActivity">
 
     <WebView
         android:layout_width="fill_parent"

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,6 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="edu.purdue.app.main.MainMenuActivity" >
+    tools:context="edu.purdue.app.activity.MainMenuActivity" >
 
     <item android:id="@+id/action_settings"
         android:title="@string/action_settings"

--- a/app/src/main/res/menu/web_view.xml
+++ b/app/src/main/res/menu/web_view.xml
@@ -1,6 +1,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="edu.purdue.app.WebViewActivity" >
+    tools:context="edu.purdue.app.activity.WebViewActivity" >
 
 
     <item

--- a/app/src/main/res/xml/app_tracker.xml
+++ b/app/src/main/res/xml/app_tracker.xml
@@ -8,10 +8,10 @@
     <bool name="ga_reportUncaughtExceptions">true</bool>
 
     <!-- The screen names that will appear in reports -->
-    <screenName name="edu.purdue.app.main.MainMenuActivity">
+    <screenName name="edu.purdue.app.activity.MainMenuActivity">
         PurdueApp MainMenuActivity
     </screenName>
-    <screenName name="edu.purdue.app.WebViewActivity">
+    <screenName name="edu.purdue.app.activity.WebViewActivity">
         PurdueApp WebViewActivity
     </screenName>
 

--- a/app/src/main/res/xml/pref_headers.xml
+++ b/app/src/main/res/xml/pref_headers.xml
@@ -3,11 +3,11 @@
     <!-- These settings headers are only used on tablets. -->
 
     <header
-        android:fragment="edu.purdue.app.prefs.GeneralPreferenceFragment"
+        android:fragment="edu.purdue.app.fragment.GeneralPreferenceFragment"
         android:title="@string/pref_header_general" />
 
     <header
-        android:fragment="edu.purdue.app.prefs.DataSyncPreferenceFragment"
+        android:fragment="edu.purdue.app.fragment.DataSyncPreferenceFragment"
         android:title="@string/pref_header_data_sync" />
 
 </preference-headers>


### PR DESCRIPTION
Pull and look at it. Idea:

```
edu.purdue.app
|-> activity
|-> adapter
|-> application
|-> constants
|-> fragment
|-> listeners
|-> model
|-> utility
```

I think its better than creating packages for each "function" of the app because it encourages reusing components. 
